### PR TITLE
Feat/#2 로그인 및 로그아웃 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,18 +45,13 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.1'
 
 	// 이메일 인증
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
-	// Test Container
-	testImplementation 'org.testcontainers:testcontainers'
-	testImplementation 'org.testcontainers:junit-jupiter'
-	testImplementation 'org.testcontainers:postgresql'
-	testImplementation 'org.testcontainers:jdbc'
 
 	// AWS S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,14 @@ dependencies {
 
 	// AWS S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// import org.springframework.data.annotation.Id;
+	implementation 'org.springframework.data:spring-data-commons'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/nayoon/preordersystem/auth/controller/LoginController.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/controller/LoginController.java
@@ -1,7 +1,7 @@
 package com.nayoon.preordersystem.auth.controller;
 
 import com.nayoon.preordersystem.auth.dto.TokenDto;
-import com.nayoon.preordersystem.auth.dto.request.SignInRequest;
+import com.nayoon.preordersystem.auth.dto.request.LoginRequest;
 import com.nayoon.preordersystem.auth.service.LoginService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +23,7 @@ public class LoginController {
    */
   @PostMapping("/login")
   public ResponseEntity<TokenDto> login(
-      @Valid @RequestBody SignInRequest request
+      @Valid @RequestBody LoginRequest request
   ) {
     return ResponseEntity.ok().body(loginService.login(request));
   }

--- a/src/main/java/com/nayoon/preordersystem/auth/controller/LoginController.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/controller/LoginController.java
@@ -1,0 +1,31 @@
+package com.nayoon.preordersystem.auth.controller;
+
+import com.nayoon.preordersystem.auth.dto.TokenDto;
+import com.nayoon.preordersystem.auth.dto.request.SignInRequest;
+import com.nayoon.preordersystem.auth.service.LoginService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/")
+public class LoginController {
+
+  private final LoginService loginService;
+
+  /**
+   * 로그인 컨트롤러
+   */
+  @PostMapping("/login")
+  public ResponseEntity<TokenDto> login(
+      @Valid @RequestBody SignInRequest request
+  ) {
+    return ResponseEntity.ok().body(loginService.login(request));
+  }
+
+}

--- a/src/main/java/com/nayoon/preordersystem/auth/controller/LogoutController.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/controller/LogoutController.java
@@ -1,0 +1,35 @@
+package com.nayoon.preordersystem.auth.controller;
+
+import com.nayoon.preordersystem.auth.dto.request.LogoutRequest;
+import com.nayoon.preordersystem.auth.security.CustomUserDetails;
+import com.nayoon.preordersystem.auth.service.LogoutService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/")
+public class LogoutController {
+
+  private final LogoutService logoutService;
+
+  /**
+   * 로그아웃 컨트롤러
+   */
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @Valid @RequestBody LogoutRequest request
+  ) {
+    logoutService.logout(request);
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
+
+}

--- a/src/main/java/com/nayoon/preordersystem/auth/dto/TokenDto.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/dto/TokenDto.java
@@ -1,0 +1,11 @@
+package com.nayoon.preordersystem.auth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record TokenDto(
+    String accessToken
+) {
+
+}

--- a/src/main/java/com/nayoon/preordersystem/auth/dto/TokenDto.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/dto/TokenDto.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record TokenDto(
-    String accessToken
+    String accessToken,
+    String refreshToken,
+    Long refreshTokenExpiresTime
 ) {
 
 }

--- a/src/main/java/com/nayoon/preordersystem/auth/dto/TokenDto.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/dto/TokenDto.java
@@ -2,7 +2,9 @@ package com.nayoon.preordersystem.auth.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
 
+@Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record TokenDto(
     String accessToken,

--- a/src/main/java/com/nayoon/preordersystem/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/dto/request/LoginRequest.java
@@ -1,10 +1,8 @@
 package com.nayoon.preordersystem.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.Builder;
 
-@Builder
-public record SignInRequest(
+public record LoginRequest(
     @NotBlank
     String email,
     @NotBlank

--- a/src/main/java/com/nayoon/preordersystem/auth/dto/request/LogoutRequest.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/dto/request/LogoutRequest.java
@@ -1,0 +1,8 @@
+package com.nayoon.preordersystem.auth.dto.request;
+
+public record LogoutRequest(
+    String accessToken,
+    String refreshToken
+) {
+
+}

--- a/src/main/java/com/nayoon/preordersystem/auth/dto/request/SignInRequest.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/dto/request/SignInRequest.java
@@ -1,0 +1,14 @@
+package com.nayoon.preordersystem.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record SignInRequest(
+    @NotBlank
+    String email,
+    @NotBlank
+    String password
+) {
+
+}

--- a/src/main/java/com/nayoon/preordersystem/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/filter/JwtAuthenticationFilter.java
@@ -1,25 +1,26 @@
 package com.nayoon.preordersystem.auth.filter;
 
 import com.nayoon.preordersystem.auth.security.JwtTokenProvider;
+import com.nayoon.preordersystem.redis.service.RedisService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
+@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtTokenProvider jwtTokenProvider;
-
-  public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
-    this.jwtTokenProvider = jwtTokenProvider;
-  }
+  private final RedisService redisService;
 
   @Override
   public void doFilterInternal(
@@ -28,10 +29,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     final String token = jwtTokenProvider.extractTokenFromRequest(request);
 
     if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
-      // 토큰이 유효한 경유 유저 정보 받기
-      Authentication authentication = jwtTokenProvider.getAuthentication(token);
-      // 인증 성공한 경우, SecurityContextHolder 에 인증 객체 설정
-      SecurityContextHolder.getContext().setAuthentication(authentication);
+      String isLogout = (String) redisService.getValue(token);
+
+      if (ObjectUtils.isEmpty(isLogout)) {
+        // 토큰이 유효한 경유 유저 정보 받기
+        Authentication authentication = jwtTokenProvider.getAuthentication(token);
+        // 인증 성공한 경우, SecurityContextHolder 에 인증 객체 설정
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      }
     }
 
     chain.doFilter(request, response); // 다음 필터로 이동

--- a/src/main/java/com/nayoon/preordersystem/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,6 @@
 package com.nayoon.preordersystem.auth.filter;
 
-import com.nayoon.preordersystem.auth.security.JwtTokenProvider;
+import com.nayoon.preordersystem.auth.service.JwtTokenProvider;
 import com.nayoon.preordersystem.redis.service.RedisService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/java/com/nayoon/preordersystem/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,40 @@
+package com.nayoon.preordersystem.auth.filter;
+
+import com.nayoon.preordersystem.auth.security.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+    this.jwtTokenProvider = jwtTokenProvider;
+  }
+
+  @Override
+  public void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain chain
+  ) throws IOException, ServletException {
+    final String token = jwtTokenProvider.extractTokenFromRequest(request);
+
+    if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+      // 토큰이 유효한 경유 유저 정보 받기
+      Authentication authentication = jwtTokenProvider.getAuthentication(token);
+      // 인증 성공한 경우, SecurityContextHolder 에 인증 객체 설정
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    chain.doFilter(request, response); // 다음 필터로 이동
+  }
+
+}

--- a/src/main/java/com/nayoon/preordersystem/auth/security/CustomUserDetails.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/security/CustomUserDetails.java
@@ -20,6 +20,10 @@ public class CustomUserDetails implements UserDetails {
     return authorities;
   }
 
+  public Long getId() {
+    return user.getId();
+  }
+
   public String getName() {
     return user.getName();
   }

--- a/src/main/java/com/nayoon/preordersystem/auth/security/CustomUserDetails.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/security/CustomUserDetails.java
@@ -1,0 +1,69 @@
+package com.nayoon.preordersystem.auth.security;
+
+import com.nayoon.preordersystem.user.entity.User;
+import java.util.ArrayList;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+  private final User user;
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    Collection<GrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(new SimpleGrantedAuthority(user.getUserRole().name()));
+    return authorities;
+  }
+
+  public String getName() {
+    return user.getName();
+  }
+
+  public String getIntroduction() {
+    return user.getIntroduction();
+  }
+
+  public String getProfileImage() {
+    return user.getProfileImage();
+  }
+
+  public boolean getVerified() {
+    return user.getVerified();
+  }
+
+  @Override
+  public String getPassword() {
+    return user.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+    return user.getEmail();
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+}

--- a/src/main/java/com/nayoon/preordersystem/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/security/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.nayoon.preordersystem.auth.security;
+
+import com.nayoon.preordersystem.common.exception.CustomException;
+import com.nayoon.preordersystem.common.exception.ErrorCode;
+import com.nayoon.preordersystem.user.entity.User;
+import com.nayoon.preordersystem.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+    return new CustomUserDetails(user);
+  }
+
+}

--- a/src/main/java/com/nayoon/preordersystem/auth/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,20 @@
+package com.nayoon.preordersystem.auth.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException) throws IOException, ServletException {
+    response.sendError(HttpServletResponse.SC_FORBIDDEN);
+  }
+
+}

--- a/src/main/java/com/nayoon/preordersystem/auth/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package com.nayoon.preordersystem.auth.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException) throws IOException {
+    response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+  }
+
+}

--- a/src/main/java/com/nayoon/preordersystem/auth/security/JwtTokenProvider.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/security/JwtTokenProvider.java
@@ -1,0 +1,116 @@
+package com.nayoon.preordersystem.auth.security;
+
+import com.nayoon.preordersystem.auth.dto.TokenDto;
+import com.nayoon.preordersystem.common.exception.CustomException;
+import com.nayoon.preordersystem.common.exception.ErrorCode;
+import com.nayoon.preordersystem.user.type.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+  private final CustomUserDetailsService customUserDetailsService;
+
+  private static long accessTokenValidationTime ; // 액세스 토큰 만료시간
+  private static SecretKey key; // secretKey를 Key 객체로 해싱
+
+  public JwtTokenProvider(
+      CustomUserDetailsService customUserDetailsService, @Value("${spring.jwt.secret}") final String secretKey,
+      @Value("${spring.jwt.token-valid-time}") final long accessTokenValidationTime
+  ) {
+    this.customUserDetailsService = customUserDetailsService;
+    this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    this.accessTokenValidationTime  = accessTokenValidationTime;
+  }
+
+  /**
+   * 토큰 생성 메서드
+   */
+  public TokenDto generateToken(String email, String name, UserRole role) {
+    Date now = new Date();
+
+    // accessToken 생성
+    String accessToken = Jwts.builder()
+        .setSubject(email)
+        .claim("name", name)
+        .claim("email", email)
+        .claim("role", role.getName())
+        .setIssuedAt(now)
+        .setExpiration(new Date(now.getTime() + accessTokenValidationTime))
+        .signWith(key, SignatureAlgorithm.HS256)
+        .compact();
+
+    return new TokenDto(accessToken);
+  }
+
+  /**
+   * 인증된 유저인지 확인
+   */
+  public Authentication getAuthentication(String token) {
+    CustomUserDetails principalDetails =
+        (CustomUserDetails) customUserDetailsService.loadUserByUsername(this.getEmail(token));
+    return new UsernamePasswordAuthenticationToken(principalDetails, "",
+        principalDetails.getAuthorities());
+  }
+
+  /**
+   * 요청에서 토큰 반환하는 메서드
+   */
+  public String extractTokenFromRequest(HttpServletRequest request) {
+    String header = request.getHeader("Authorization");
+    if (header != null && header.startsWith("Bearer ")) {
+      return header.substring("Bearer ".length()); // "Bearer " 부분을 제외한 토큰 값 반환
+    }
+    return null;
+  }
+
+  /**
+   * 토큰에서 아이디 추출하는 메서드
+   */
+  public String getEmail(String token) {
+    if (!validateToken(token)) {
+      throw new CustomException(ErrorCode.INVALID_AUTHENTICATION_TOKEN);
+    }
+
+    return extractClaims(token).get("email", String.class);
+  }
+
+  /**
+   * 토큰이 유효한지 확인하는 메서드
+   */
+  public boolean validateToken(String token) {
+    try {
+
+      Claims claims = extractClaims(token);
+      return claims.getExpiration().after(new Date());
+
+    } catch (ExpiredJwtException e) {
+      throw new CustomException(ErrorCode.EXPIRED_AUTHENTICATION_TOKEN);
+    } catch (JwtException | IllegalArgumentException e) {
+      throw new CustomException(ErrorCode.INVALID_AUTHENTICATION_TOKEN);
+    }
+  }
+
+  /**
+   * 토큰에러 Claims 추출하는 메서드
+   */
+  private Claims extractClaims(String token) {
+    return Jwts.parserBuilder().setSigningKey(key).build()
+        .parseClaimsJws(token)
+        .getBody();
+  }
+
+}

--- a/src/main/java/com/nayoon/preordersystem/auth/service/JwtTokenProvider.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/service/JwtTokenProvider.java
@@ -1,6 +1,8 @@
-package com.nayoon.preordersystem.auth.security;
+package com.nayoon.preordersystem.auth.service;
 
 import com.nayoon.preordersystem.auth.dto.TokenDto;
+import com.nayoon.preordersystem.auth.security.CustomUserDetails;
+import com.nayoon.preordersystem.auth.security.CustomUserDetailsService;
 import com.nayoon.preordersystem.common.exception.CustomException;
 import com.nayoon.preordersystem.common.exception.ErrorCode;
 import com.nayoon.preordersystem.user.type.UserRole;
@@ -66,7 +68,7 @@ public class JwtTokenProvider {
         .signWith(key, SignatureAlgorithm.HS256)
         .compact();
 
-    return new TokenDto(accessToken, refreshToken, now.getTime() + refreshTokenValidationTime);
+    return new TokenDto(accessToken, refreshToken, refreshTokenValidationTime);
   }
 
   /**

--- a/src/main/java/com/nayoon/preordersystem/auth/service/LoginService.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/service/LoginService.java
@@ -1,7 +1,7 @@
 package com.nayoon.preordersystem.auth.service;
 
 import com.nayoon.preordersystem.auth.dto.TokenDto;
-import com.nayoon.preordersystem.auth.dto.request.SignInRequest;
+import com.nayoon.preordersystem.auth.dto.request.LoginRequest;
 import com.nayoon.preordersystem.common.exception.CustomException;
 import com.nayoon.preordersystem.common.exception.ErrorCode;
 import com.nayoon.preordersystem.common.utils.EncryptionUtils;
@@ -18,17 +18,16 @@ public class LoginService {
 
   private final UserRepository userRepository;
   private final JwtTokenProvider jwtTokenProvider;
-  private final EncryptionUtils encryptionUtils;
   private final RedisService redisService;
 
   /**
    * 사용자 로그인 메서드
    */
-  public TokenDto login(SignInRequest request) {
+  public TokenDto login(LoginRequest request) {
     User user = userRepository.findByEmail(request.email())
         .orElseThrow(() -> new CustomException(ErrorCode.INCORRECT_EMAIL_OR_PASSWORD));
 
-    if (!encryptionUtils.matchPassword(request.password(), user.getPassword())) {
+    if (!EncryptionUtils.matchPassword(request.password(), user.getPassword())) {
       throw new CustomException(ErrorCode.INCORRECT_EMAIL_OR_PASSWORD);
     }
 

--- a/src/main/java/com/nayoon/preordersystem/auth/service/LoginService.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/service/LoginService.java
@@ -1,0 +1,36 @@
+package com.nayoon.preordersystem.auth.service;
+
+import com.nayoon.preordersystem.auth.dto.TokenDto;
+import com.nayoon.preordersystem.auth.dto.request.SignInRequest;
+import com.nayoon.preordersystem.auth.security.JwtTokenProvider;
+import com.nayoon.preordersystem.common.exception.CustomException;
+import com.nayoon.preordersystem.common.exception.ErrorCode;
+import com.nayoon.preordersystem.common.utils.EncryptionUtils;
+import com.nayoon.preordersystem.user.entity.User;
+import com.nayoon.preordersystem.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+
+  private final UserRepository userRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+  private final EncryptionUtils encryptionUtils;
+
+  /**
+   * 사용자 로그인 메서드
+   */
+  public TokenDto login(SignInRequest request) {
+    User user = userRepository.findByEmail(request.email())
+        .orElseThrow(() -> new CustomException(ErrorCode.INCORRECT_EMAIL_OR_PASSWORD));
+
+    if (!encryptionUtils.matchPassword(request.password(), user.getPassword())) {
+      throw new CustomException(ErrorCode.INCORRECT_EMAIL_OR_PASSWORD);
+    }
+
+    return jwtTokenProvider.generateToken(user.getEmail(), user.getName(), user.getUserRole());
+  }
+
+}

--- a/src/main/java/com/nayoon/preordersystem/auth/service/LoginService.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/service/LoginService.java
@@ -2,7 +2,6 @@ package com.nayoon.preordersystem.auth.service;
 
 import com.nayoon.preordersystem.auth.dto.TokenDto;
 import com.nayoon.preordersystem.auth.dto.request.SignInRequest;
-import com.nayoon.preordersystem.auth.security.JwtTokenProvider;
 import com.nayoon.preordersystem.common.exception.CustomException;
 import com.nayoon.preordersystem.common.exception.ErrorCode;
 import com.nayoon.preordersystem.common.utils.EncryptionUtils;

--- a/src/main/java/com/nayoon/preordersystem/auth/service/LogoutService.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/service/LogoutService.java
@@ -1,7 +1,6 @@
 package com.nayoon.preordersystem.auth.service;
 
 import com.nayoon.preordersystem.auth.dto.request.LogoutRequest;
-import com.nayoon.preordersystem.auth.security.JwtTokenProvider;
 import com.nayoon.preordersystem.common.exception.CustomException;
 import com.nayoon.preordersystem.common.exception.ErrorCode;
 import com.nayoon.preordersystem.redis.service.RedisService;

--- a/src/main/java/com/nayoon/preordersystem/auth/service/LogoutService.java
+++ b/src/main/java/com/nayoon/preordersystem/auth/service/LogoutService.java
@@ -1,0 +1,42 @@
+package com.nayoon.preordersystem.auth.service;
+
+import com.nayoon.preordersystem.auth.dto.request.LogoutRequest;
+import com.nayoon.preordersystem.auth.security.JwtTokenProvider;
+import com.nayoon.preordersystem.common.exception.CustomException;
+import com.nayoon.preordersystem.common.exception.ErrorCode;
+import com.nayoon.preordersystem.redis.service.RedisService;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LogoutService {
+
+  private final JwtTokenProvider jwtTokenProvider;
+  private final RedisService redisService;
+
+  @Transactional
+  public void logout(LogoutRequest request) {
+    String accessToken = request.accessToken();
+
+    if (!jwtTokenProvider.validateToken(accessToken)) {
+      throw new CustomException(ErrorCode.INVALID_AUTHENTICATION_TOKEN);
+    }
+
+    Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+
+    // Redis에 현재 사용자의 이메일로 저장된 refreshToken이 있으면 삭제
+    String redisKey = "RT:" + authentication.getName();
+    if (redisService.getValue(redisKey) != null) {
+      redisService.deleteKey(redisKey);
+    }
+
+    // 해당 accessToken 유효시간을 블랙리스트에 저장
+    Long expiration = jwtTokenProvider.getAccessTokenExpiration(accessToken);
+    redisService.setValues(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+  }
+
+}

--- a/src/main/java/com/nayoon/preordersystem/common/config/SecurityConfig.java
+++ b/src/main/java/com/nayoon/preordersystem/common/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
                 antMatcher("/"),
                 antMatcher("/api/v1/users/signup"),
                 antMatcher("/api/v1/users/emails/**"),
-                antMatcher("/api/v1/users/emails/verifications/**")
+                antMatcher("/api/v1/users/emails/verifications/**"),
+                antMatcher("/api/v1/login")
             ).permitAll()
             .anyRequest().authenticated()
         )

--- a/src/main/java/com/nayoon/preordersystem/common/config/SecurityConfig.java
+++ b/src/main/java/com/nayoon/preordersystem/common/config/SecurityConfig.java
@@ -2,6 +2,9 @@ package com.nayoon.preordersystem.common.config;
 
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
 
+import com.nayoon.preordersystem.auth.filter.JwtAuthenticationFilter;
+import com.nayoon.preordersystem.auth.security.JwtAccessDeniedHandler;
+import com.nayoon.preordersystem.auth.security.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,11 +14,16 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+  private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
   @Bean
   public BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -43,6 +51,11 @@ public class SecurityConfig {
             ).permitAll()
             .anyRequest().authenticated()
         )
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling(handle -> handle
+            .authenticationEntryPoint(jwtAuthenticationEntryPoint))
+        .exceptionHandling(handle -> handle
+            .accessDeniedHandler(jwtAccessDeniedHandler))
     ;
 
     return http.build();

--- a/src/main/java/com/nayoon/preordersystem/common/exception/ErrorCode.java
+++ b/src/main/java/com/nayoon/preordersystem/common/exception/ErrorCode.java
@@ -22,6 +22,13 @@ public enum ErrorCode {
   // S3
   NO_FILE(HttpStatus.BAD_REQUEST, "설정할 파일이 없습니다."),
 
+  // Auth
+  INCORRECT_EMAIL_OR_PASSWORD(HttpStatus.BAD_REQUEST, "아이디 또는 비밀번호가 올바르지 않습니다."),
+  EMPTY_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "인증 헤더가 없습니다."),
+  INVALID_AUTHENTICATION_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 토큰입니다."),
+  EXPIRED_AUTHENTICATION_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+  NOT_AUTHORIZATION(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
+
 
   // ------ 5xx ------
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다."),

--- a/src/main/java/com/nayoon/preordersystem/redis/service/RedisService.java
+++ b/src/main/java/com/nayoon/preordersystem/redis/service/RedisService.java
@@ -2,7 +2,7 @@ package com.nayoon.preordersystem.redis.service;
 
 import com.nayoon.preordersystem.common.exception.CustomException;
 import com.nayoon.preordersystem.common.exception.ErrorCode;
-import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -15,8 +15,8 @@ public class RedisService {
     this.redisTemplate = redisTemplate;
   }
 
-  public void setValues(String key, Object value, Duration duration) {
-    redisTemplate.opsForValue().set(key, value, duration);
+  public void setValues(String key, Object value, Long expiration, TimeUnit timeUnit) {
+    redisTemplate.opsForValue().set(key, value, expiration, timeUnit);
   }
 
   public Object getValue(String key) {

--- a/src/main/java/com/nayoon/preordersystem/user/controller/UserController.java
+++ b/src/main/java/com/nayoon/preordersystem/user/controller/UserController.java
@@ -27,19 +27,18 @@ public class UserController {
    * 회원가입 컨트롤러
    */
   @PostMapping("/signup")
-  public ResponseEntity<Void> signup(
+  public ResponseEntity<String> signup(
       @Valid @RequestPart("data") SignUpRequest request,
       @RequestPart(name = "profileImage") MultipartFile imageFile
   ) throws IOException {
-    userService.signup(request, imageFile);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
+    return ResponseEntity.status(HttpStatus.CREATED).body(userService.signup(request, imageFile));
   }
 
   /**
    * 인증 메일 전송 컨트롤러
    */
   @PostMapping("/emails")
-  public ResponseEntity<Void> sendEmail(
+  public ResponseEntity<String> sendEmail(
       @Valid @RequestBody String email
   ) {
     userService.sendCode(email);

--- a/src/main/java/com/nayoon/preordersystem/user/service/UserService.java
+++ b/src/main/java/com/nayoon/preordersystem/user/service/UserService.java
@@ -43,7 +43,7 @@ public class UserService {
    * 회원가입 메서드
    */
   @Transactional
-  public void signup(SignUpRequest request, MultipartFile imageFile) throws IOException {
+  public String signup(SignUpRequest request, MultipartFile imageFile) throws IOException {
     // 비밀번호 암호화
     String encryptPassword = EncryptionUtils.encode(request.password());
 
@@ -68,7 +68,7 @@ public class UserService {
     user.updateProfileImage(s3ImageUrl);
 
     // 이메일로 인증 코드 전송
-    sendCode(request.email());
+    return sendCode(request.email());
   }
 
   /**

--- a/src/main/java/com/nayoon/preordersystem/user/service/UserService.java
+++ b/src/main/java/com/nayoon/preordersystem/user/service/UserService.java
@@ -15,6 +15,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -90,7 +91,7 @@ public class UserService {
     mailService.sendEmail(toEmail, title, authCode);
 
     // key = "AuthCode" + email, value = authCode 형식으로 Redis에 저장
-    redisService.setValues(AUTH_PREFIX + toEmail, authCode, Duration.ofMillis(authCodeExpirationMillis));
+    redisService.setValues(AUTH_PREFIX + toEmail, authCode, authCodeExpirationMillis, TimeUnit.MILLISECONDS);
     return authCode;
   }
 

--- a/src/main/java/com/nayoon/preordersystem/user/type/UserRole.java
+++ b/src/main/java/com/nayoon/preordersystem/user/type/UserRole.java
@@ -2,14 +2,21 @@ package com.nayoon.preordersystem.user.type;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 
 @Getter
 @RequiredArgsConstructor
-public enum UserRole {
+public enum UserRole implements GrantedAuthority {
 
   USER("ROLE_USER"),
   ADMIN("ROLE_ADMIN");
 
-  private final String key;
+  private final String name;
+
+  @Override
+  public String getAuthority() {
+    return name();
+  }
 
 }

--- a/src/test/java/com/nayoon/preordersystem/auth/service/LoginServiceTest.java
+++ b/src/test/java/com/nayoon/preordersystem/auth/service/LoginServiceTest.java
@@ -1,0 +1,152 @@
+package com.nayoon.preordersystem.auth.service;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.nayoon.preordersystem.auth.dto.TokenDto;
+import com.nayoon.preordersystem.auth.dto.request.LoginRequest;
+import com.nayoon.preordersystem.common.exception.CustomException;
+import com.nayoon.preordersystem.common.exception.ErrorCode;
+import com.nayoon.preordersystem.common.utils.EncryptionUtils;
+import com.nayoon.preordersystem.redis.service.RedisService;
+import com.nayoon.preordersystem.user.entity.User;
+import com.nayoon.preordersystem.user.repository.UserRepository;
+import com.nayoon.preordersystem.user.type.UserRole;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class LoginServiceTest {
+
+  @InjectMocks
+  private LoginService loginService;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private JwtTokenProvider jwtTokenProvider;
+
+  @Mock
+  private RedisService redisService;
+
+  private static MockedStatic<EncryptionUtils> mEncryptionUtils;
+
+  @BeforeAll
+  static void beforeClass() {
+    mEncryptionUtils = mockStatic(EncryptionUtils.class);
+  }
+
+  @AfterAll
+  static void afterClass() {
+    mEncryptionUtils.close();
+  }
+
+  @Nested
+  @DisplayName("로그인")
+  class login {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      //given
+      User user = createUser(true);
+      LoginRequest request = createLoginRequest();
+      TokenDto tokenDto = createTokenDto();
+
+      when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+      when(EncryptionUtils.matchPassword(request.password(), user.getPassword())).thenReturn(true);
+      when(jwtTokenProvider.generateToken(user.getEmail(), user.getName(),
+          user.getUserRole())).thenReturn(tokenDto);
+
+      //when
+      TokenDto result = loginService.login(request);
+
+      //then
+      assertNotNull(result);
+      assertEquals(tokenDto, result);
+      verify(redisService, times(1)).setValues(eq("RT:" + user.getEmail()),
+          eq(tokenDto.refreshToken()), eq(tokenDto.refreshTokenExpiresTime()),
+          eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    @DisplayName("실패: 해당 이메일로 가입된 사용자 없음")
+    void invalidEmail() {
+      //given
+      LoginRequest request = createLoginRequest();
+
+      //when
+      CustomException exception = assertThrows(CustomException.class,
+          () -> loginService.login(request));
+
+      //then
+      assertEquals(ErrorCode.INCORRECT_EMAIL_OR_PASSWORD, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("실패: 비밀번호 다름")
+    void invalidPassword() {
+      //given
+      User user = createUser(true);
+      LoginRequest request = createInvalidLoginRequest();
+
+      when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+      when(EncryptionUtils.matchPassword(request.password(), user.getPassword())).thenReturn(false);
+
+      //when
+      CustomException exception = assertThrows(CustomException.class,
+          () -> loginService.login(request));
+
+      //then
+      assertEquals(ErrorCode.INCORRECT_EMAIL_OR_PASSWORD, exception.getErrorCode());
+    }
+
+  }
+
+  private LoginRequest createLoginRequest() {
+    return new LoginRequest("test@example.com", "password");
+  }
+
+  private LoginRequest createInvalidLoginRequest() {
+    return new LoginRequest("test@example.com", "passwor");
+  }
+
+  private User createUser(boolean verified) {
+    return User.builder()
+        .email("test@example.com")
+        .name("Test User")
+        .password("password")
+        .introduction("Hello, I'm a test user.")
+        .userRole(UserRole.USER)
+        .verified(verified)
+        .build();
+  }
+
+  private TokenDto createTokenDto() {
+    return TokenDto.builder()
+        .accessToken("accessToken")
+        .refreshToken("refreshToken")
+        .refreshTokenExpiresTime(1000L)
+        .build();
+  }
+
+}

--- a/src/test/java/com/nayoon/preordersystem/auth/service/LogoutServiceTest.java
+++ b/src/test/java/com/nayoon/preordersystem/auth/service/LogoutServiceTest.java
@@ -1,0 +1,86 @@
+package com.nayoon.preordersystem.auth.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.nayoon.preordersystem.auth.dto.request.LogoutRequest;
+import com.nayoon.preordersystem.common.exception.CustomException;
+import com.nayoon.preordersystem.common.exception.ErrorCode;
+import com.nayoon.preordersystem.redis.service.RedisService;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class LogoutServiceTest {
+
+  @InjectMocks
+  private LogoutService logoutService;
+
+  @Mock
+  private JwtTokenProvider jwtTokenProvider;
+
+  @Mock
+  private RedisService redisService;
+
+  @Nested
+  @DisplayName("로그아웃")
+  class logout {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      //given
+      LogoutRequest request = createLogoutRequest();
+      when(jwtTokenProvider.validateToken(request.accessToken())).thenReturn(true);
+
+      Authentication authentication = mock(Authentication.class);
+      when(authentication.getName()).thenReturn("authenticatedUserEmail");
+      when(jwtTokenProvider.getAuthentication(request.accessToken())).thenReturn(authentication);
+
+      //when
+      logoutService.logout(request);
+
+      //then
+      verify(jwtTokenProvider, times(1)).validateToken(request.accessToken());
+      verify(jwtTokenProvider, times(1)).getAuthentication(request.accessToken());
+      verify(redisService, times(1)).setValues(eq(request.accessToken()), eq("logout"),
+          anyLong(), eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    @DisplayName("실패: 유효하지 않은 토큰")
+    void invalidToken() {
+      //given
+      LogoutRequest request = createLogoutRequest();
+      when(jwtTokenProvider.validateToken(request.accessToken())).thenReturn(false);
+
+      //when
+      CustomException exception = assertThrows(CustomException.class,
+          () -> logoutService.logout(request));
+
+      //then
+      assertEquals(ErrorCode.INVALID_AUTHENTICATION_TOKEN, exception.getErrorCode());
+    }
+
+  }
+
+  public LogoutRequest createLogoutRequest() {
+    return new LogoutRequest("accessToken", "refreshToken");
+  }
+
+}

--- a/src/test/java/com/nayoon/preordersystem/user/service/UserServiceTest.java
+++ b/src/test/java/com/nayoon/preordersystem/user/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.nayoon.preordersystem.user.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -106,7 +107,7 @@ class UserServiceTest {
 
       //then
       verify(mailService, times(1)).sendEmail(eq(email), anyString(), anyString());
-      verify(redisService, times(1)).setValues(anyString(), anyString(), any(), TimeUnit.MILLISECONDS);
+      verify(redisService, times(1)).setValues(anyString(), anyString(), anyLong(), eq(TimeUnit.MILLISECONDS));
     }
 
   }

--- a/src/test/java/com/nayoon/preordersystem/user/service/UserServiceTest.java
+++ b/src/test/java/com/nayoon/preordersystem/user/service/UserServiceTest.java
@@ -22,6 +22,7 @@ import com.nayoon.preordersystem.user.repository.UserRepository;
 import com.nayoon.preordersystem.user.type.UserRole;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -105,7 +106,7 @@ class UserServiceTest {
 
       //then
       verify(mailService, times(1)).sendEmail(eq(email), anyString(), anyString());
-      verify(redisService, times(1)).setValues(anyString(), anyString(), any());
+      verify(redisService, times(1)).setValues(anyString(), anyString(), any(), TimeUnit.MILLISECONDS);
     }
 
   }


### PR DESCRIPTION
### 이슈 번호
#2 

### PR 유형
- [x] 신규 기능

### 변경사항
- 로그인
  - 이메일과 비밀번호가 올바른지 확인
  - JWT 토큰 생성: AccessToken & RefreshToken
  - Redis에 RefreshToken 저장

- 로그아웃
  - AccessToken이 유효한지 확인
  - AccessToken 이용하여 유저 인증 확인
  - Redis에 현재 key가 현재 사용자 이메일인 RefreshToken이 있다면 삭제
  - AccessToken 및 유효시간을 "logout" 문자를 포함시켜 저장

- 만약 Redis를 AccessToken으로 조회했을 때 내용이 비어있지 않다면("logout"이 들어있다.) 인증을 통과할 수 없다.

### 테스트
- [x] 테스트 코드
  - [x] LoginService
  - [x] LogoutService
- [x] API 테스트

### ETC